### PR TITLE
Update dependency version for http package in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.12.2
+  http: ^0.13.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
After upgrading the packages in my app I am getting a version conflict on global_configuration. Would it be possible to support `http: ^0.13.0` pls?